### PR TITLE
MOL-215 Save arkivkopi request to the database

### DIFF
--- a/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
+++ b/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
@@ -1,24 +1,12 @@
-import pytz
 from datetime import datetime
-from urllib.parse import parse_qs
-
 from sqlalchemy.orm import Session
 
 from app.database.dbo.mottak import Arkivkopi as Arkivkopi_DBO
 from app.domain.models.Arkivkopi import ArkivkopiStatus
 
 
-def convert_to_datetime(datetime_string: str):
-    iso_8601 = '%Y-%m-%dT%H:%M:%S%z'
-    return datetime.strptime(datetime_string, iso_8601).astimezone(pytz.timezone("Europe/Oslo"))
-
-
 def create(db: Session, arkivuttrekk_id: int, status: ArkivkopiStatus, storage_account: str, container: str,
-           sas_token: str) -> Arkivkopi_DBO:
-    query_string = parse_qs(sas_token)
-    sas_token_start = convert_to_datetime(query_string["st"][0])
-    sas_token_slutt = convert_to_datetime(query_string["se"][0])
-
+           sas_token_start: datetime, sas_token_slutt: datetime) -> Arkivkopi_DBO:
     dbo = Arkivkopi_DBO(arkivuttrekk_id=arkivuttrekk_id,
                         status=status,
                         storage_account=storage_account,

--- a/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
+++ b/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
@@ -1,8 +1,7 @@
-from datetime import datetime
 from sqlalchemy.orm import Session
 
 from app.database.dbo.mottak import Arkivkopi as Arkivkopi_DBO
-from app.domain.models.Arkivkopi import Arkivkopi, ArkivkopiStatus
+from app.domain.models.Arkivkopi import Arkivkopi
 
 
 def create(db: Session, arkivkopi: Arkivkopi) -> Arkivkopi_DBO:

--- a/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
+++ b/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
@@ -1,0 +1,32 @@
+import pytz
+from datetime import datetime
+from urllib.parse import parse_qs
+
+from sqlalchemy.orm import Session
+
+from app.database.dbo.mottak import Arkivkopi as Arkivkopi_DBO
+from app.domain.models.Arkivkopi import ArkivkopiStatus
+
+
+def convert_to_datetime(datetime_string: str):
+    iso_8601 = '%Y-%m-%dT%H:%M:%S%z'
+    return datetime.strptime(datetime_string, iso_8601).astimezone(pytz.timezone("Europe/Oslo"))
+
+
+def create(db: Session, arkivuttrekk_id: int, status: ArkivkopiStatus, storage_account: str, container: str,
+           sas_token: str) -> Arkivkopi_DBO:
+    query_string = parse_qs(sas_token)
+    sas_token_start = convert_to_datetime(query_string["st"][0])
+    sas_token_slutt = convert_to_datetime(query_string["se"][0])
+
+    dbo = Arkivkopi_DBO(arkivuttrekk_id=arkivuttrekk_id,
+                        status=status,
+                        storage_account=storage_account,
+                        container=container,
+                        sas_token_start=sas_token_start,
+                        sas_token_slutt=sas_token_slutt,
+                        )
+
+    db.add(dbo)
+    db.commit()
+    return dbo

--- a/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
+++ b/mottak-arkiv-service/app/database/repositories/arkivkopi_repository.py
@@ -2,19 +2,11 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 
 from app.database.dbo.mottak import Arkivkopi as Arkivkopi_DBO
-from app.domain.models.Arkivkopi import ArkivkopiStatus
+from app.domain.models.Arkivkopi import Arkivkopi, ArkivkopiStatus
 
 
-def create(db: Session, arkivuttrekk_id: int, status: ArkivkopiStatus, storage_account: str, container: str,
-           sas_token_start: datetime, sas_token_slutt: datetime) -> Arkivkopi_DBO:
-    dbo = Arkivkopi_DBO(arkivuttrekk_id=arkivuttrekk_id,
-                        status=status,
-                        storage_account=storage_account,
-                        container=container,
-                        sas_token_start=sas_token_start,
-                        sas_token_slutt=sas_token_slutt,
-                        )
-
+def create(db: Session, arkivkopi: Arkivkopi) -> Arkivkopi_DBO:
+    dbo = Arkivkopi_DBO(**vars(arkivkopi))
     db.add(dbo)
     db.commit()
     return dbo

--- a/mottak-arkiv-service/app/domain/arkivuttrekk_service.py
+++ b/mottak-arkiv-service/app/domain/arkivuttrekk_service.py
@@ -10,9 +10,9 @@ from app.connectors.mailgun.mailgun_client import MailgunClient
 from app.connectors.sas_generator.sas_generator_client import SASGeneratorClient
 from app.connectors.sas_generator.models import SASResponse
 from app.database.dbo.mottak import Invitasjon, Arkivuttrekk as Arkivuttrekk_DBO
-from app.database.repositories import arkivuttrekk_repository, invitasjon_repository
+from app.database.repositories import arkivkopi_repository, arkivuttrekk_repository, invitasjon_repository
 from app.domain.models.Arkivuttrekk import Arkivuttrekk
-from app.domain.models.Arkivkopi import ArkivkopiRequest
+from app.domain.models.Arkivkopi import ArkivkopiRequest, ArkivkopiStatus
 from app.domain.models.Invitasjon import InvitasjonStatus
 from app.exceptions import ArkivuttrekkNotFound
 
@@ -55,13 +55,16 @@ async def request_download(arkivuttrekk_id: int, db: Session):
     arkivuttrekk = get_by_id(arkivuttrekk_id, db)
     sas_token = await _request_sas_token(arkivuttrekk)
     if not sas_token:
-        return {"status": 500}
+        return False
 
     request_download = await _request_download(sas_token, arkivuttrekk)
     if not request_download:
-        return {"status": 500}
+        return False
 
-    return {"status": 200}
+    return arkivkopi_repository.create(db, arkivuttrekk.id, ArkivkopiStatus.BESTILT,
+                                       storage_account=sas_token["storage_account"],
+                                       container=sas_token["container"],
+                                       sas_token=sas_token["sas_token"])
 
 
 async def _request_sas_token(arkivuttrekk: Arkivuttrekk_DBO):

--- a/mottak-arkiv-service/app/domain/arkivuttrekk_service.py
+++ b/mottak-arkiv-service/app/domain/arkivuttrekk_service.py
@@ -59,10 +59,6 @@ async def request_download(arkivuttrekk_id: int, db: Session) -> Optional[Arkivk
     if not sas_token:
         return None
 
-    request_download = await _request_download(sas_token, arkivuttrekk)
-    if not request_download:
-        return None
-
     query_string = parse_qs(sas_token["sas_token"])
     sas_token_start = convert_string_to_datetime(query_string["st"][0])
     sas_token_slutt = convert_string_to_datetime(query_string["se"][0])
@@ -73,6 +69,10 @@ async def request_download(arkivuttrekk_id: int, db: Session) -> Optional[Arkivk
                                             sas_token_start=sas_token_start,
                                             sas_token_slutt=sas_token_slutt)
 
+    request_download = await _request_download(sas_token, arkivkopi)
+    if not request_download:
+        return None
+
     return arkivkopi
 
 
@@ -82,8 +82,8 @@ async def _request_sas_token(arkivuttrekk: Arkivuttrekk_DBO):
     return await sas_generator_client.request_sas(arkivuttrekk.obj_id)
 
 
-async def _request_download(sas_token: SASResponse, arkivuttrekk: Arkivuttrekk_DBO):
-    arkivkopi_request = ArkivkopiRequest(arkivkopi_id=arkivuttrekk.id,
+async def _request_download(sas_token: SASResponse, arkivkopi: Arkivkopi_DBO):
+    arkivkopi_request = ArkivkopiRequest(arkivkopi_id=arkivkopi.id,
                                          storage_account=sas_token["storage_account"],
                                          container=sas_token["container"],
                                          sas_token=sas_token["sas_token"])

--- a/mottak-arkiv-service/app/domain/models/Arkivkopi.py
+++ b/mottak-arkiv-service/app/domain/models/Arkivkopi.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from datetime import datetime
 
 import json
 from enum import Enum
@@ -11,6 +12,38 @@ class UUIDEncoder(json.JSONEncoder):
             # if the obj is uuid, we simply return the value of uuid
             return str(obj)
         return json.JSONEncoder.default(self, obj)
+
+
+class Arkivkopi:
+    id: int
+    arkivuttrekk_id: int
+    status: ArkivkopiStatus
+    storage_account: str
+    container: str
+    sas_token_start: datetime
+    sas_token_slutt: datetime
+    opprettet: datetime
+    endret: datetime
+
+    def __init__(self,
+                 id_=None,
+                 arkivuttrekk_id=None,
+                 status=None,
+                 storage_account=None,
+                 container=None,
+                 sas_token_start=None,
+                 sas_token_slutt=None,
+                 opprettet=None,
+                 endret=None):
+        self.id = id_
+        self.arkivuttrekk_id = arkivuttrekk_id
+        self.status = status
+        self.storage_account = storage_account
+        self.container = container
+        self.sas_token_start = sas_token_start
+        self.sas_token_slutt = sas_token_slutt
+        self.opprettet = opprettet
+        self.endret = endret
 
 
 class ArkivkopiRequest:

--- a/mottak-arkiv-service/app/domain/models/Arkivkopi.py
+++ b/mottak-arkiv-service/app/domain/models/Arkivkopi.py
@@ -4,6 +4,10 @@ from datetime import datetime
 import json
 from enum import Enum
 from uuid import UUID
+from urllib.parse import parse_qs
+
+from app.connectors.sas_generator.models import SASResponse
+from app.utils import convert_string_to_datetime
 
 
 class UUIDEncoder(json.JSONEncoder):
@@ -45,6 +49,18 @@ class Arkivkopi:
         self.opprettet = opprettet
         self.endret = endret
 
+    def from_id_and_token(arkivuttrekk_id: int, sas_token: SASResponse) -> Arkivkopi:
+        query_string = parse_qs(sas_token["sas_token"])
+        sas_token_start = convert_string_to_datetime(query_string["st"][0])
+        sas_token_slutt = convert_string_to_datetime(query_string["se"][0])
+
+        return Arkivkopi(arkivuttrekk_id=arkivuttrekk_id,
+                         status=ArkivkopiStatus.BESTILT,
+                         storage_account=sas_token["storage_account"],
+                         container=sas_token["container"],
+                         sas_token_start=sas_token_start,
+                         sas_token_slutt=sas_token_slutt)
+
 
 class ArkivkopiRequest:
     """
@@ -69,6 +85,12 @@ class ArkivkopiRequest:
                    self.container == other.container and \
                    self.sas_token == other.sas_token
         return False
+
+    def from_id_and_token(arkivkopi_id: int, sas_token: SASResponse) -> ArkivkopiRequest:
+        return ArkivkopiRequest(arkivkopi_id=arkivkopi_id,
+                                storage_account=sas_token["storage_account"],
+                                container=sas_token["container"],
+                                sas_token=sas_token["sas_token"])
 
     def as_json_str(self):
         return json.dumps(self.__dict__, cls=UUIDEncoder, default=str)

--- a/mottak-arkiv-service/app/routers/arkivuttrekk.py
+++ b/mottak-arkiv-service/app/routers/arkivuttrekk.py
@@ -68,8 +68,6 @@ async def request_download(id: int, db: Session = Depends(get_db_session)):
     except ArkivuttrekkNotFound as err:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err.message)
 
-    if result["status"] != 200:
+    if not result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                             detail='Bestilling feilet, venligst prøv igjen senere')
-
-    return result

--- a/mottak-arkiv-service/app/utils.py
+++ b/mottak-arkiv-service/app/utils.py
@@ -1,3 +1,6 @@
+import pytz
+
+from datetime import datetime
 from pathlib import Path
 
 
@@ -8,3 +11,8 @@ def get_project_root() -> Path:
     :return:
     """
     return Path(__file__).parent.parent
+
+
+def convert_string_to_datetime(datetime_string: str):
+    iso_8601 = '%Y-%m-%dT%H:%M:%S%z'
+    return datetime.strptime(datetime_string, iso_8601).astimezone(pytz.timezone("Europe/Oslo"))

--- a/mottak-arkiv-service/poetry.lock
+++ b/mottak-arkiv-service/poetry.lock
@@ -537,6 +537,14 @@ python-versions = "*"
 six = ">=1.4.0"
 
 [[package]]
+name = "pytz"
+version = "2020.5"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "requests"
 version = "2.25.1"
 description = "Python HTTP for Humans."
@@ -700,7 +708,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a9bdf25cc9b584b1bd887e5d2abc7c68f6b39b278b03892a4ba82db507e69ff7"
+content-hash = "49bb14b873ff93a4a66e6792a547a97f96c1823180e95f35d1cb2930d6a029c3"
 
 [metadata.files]
 adal = [
@@ -1053,6 +1061,10 @@ python-editor = [
 ]
 python-multipart = [
     {file = "python-multipart-0.0.5.tar.gz", hash = "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"},
+]
+pytz = [
+    {file = "pytz-2020.5-py2.py3-none-any.whl", hash = "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"},
+    {file = "pytz-2020.5.tar.gz", hash = "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"},
 ]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},

--- a/mottak-arkiv-service/pyproject.toml
+++ b/mottak-arkiv-service/pyproject.toml
@@ -13,6 +13,7 @@ alembic = "^1.4.2"
 psycopg2 = "^2.8.6"
 httpx = "^0.16.1"
 azure-servicebus = "^0.50.3"
+pytz = "^2020.5"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4.4"


### PR DESCRIPTION
The `pytz` dependency could be dropped if we upgrade to Python 3.9 which has ZoneInfo as a std lib
https://docs.python.org/3.9/library/zoneinfo.html