### PR TITLE
MOL-241 Fix 404 error when reloading web application

### DIFF
--- a/mottak-arkiv-web/Dockerfile
+++ b/mottak-arkiv-web/Dockerfile
@@ -22,6 +22,7 @@ EXPOSE 80
 WORKDIR /usr/share/nginx/html
 
 COPY env.sh .
+COPY default.conf /etc/nginx/conf.d/default.conf
 
 # Make our shell script executable
 RUN chmod +x env.sh

--- a/mottak-arkiv-web/Dockerfile
+++ b/mottak-arkiv-web/Dockerfile
@@ -17,9 +17,9 @@ RUN yarn build
 
 # production environment
 FROM nginx:stable-alpine
-COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 80
-WORKDIR /usr/share/nginx/html
+WORKDIR /app
+
+COPY --from=build /app/build /app/public
 
 COPY env.sh .
 COPY default.conf /etc/nginx/conf.d/default.conf
@@ -27,5 +27,6 @@ COPY default.conf /etc/nginx/conf.d/default.conf
 # Make our shell script executable
 RUN chmod +x env.sh
 
+EXPOSE 80
 # Start Nginx server
-CMD ["/bin/sh", "-c", "/usr/share/nginx/html/env.sh && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "/app/env.sh && nginx -g 'daemon off;'"]

--- a/mottak-arkiv-web/default.conf
+++ b/mottak-arkiv-web/default.conf
@@ -1,0 +1,10 @@
+server {
+	listen              80;
+	server_name         localhost;
+	root                /usr/share/nginx/html;
+	index               index.html index.htm;
+
+	location / {
+		try_files $uri /index.html;
+	}
+}

--- a/mottak-arkiv-web/default.conf
+++ b/mottak-arkiv-web/default.conf
@@ -4,7 +4,23 @@ server {
 	root                /app/public;
 	index               index.html index.htm;
 
+	location ~* \.(?:manifest|appcache|html?|xml|json)$ {
+		expires -1;
+	}
+
+	location ~* \.(?:css|js)$ {
+		try_files $uri =404;
+		access_log off;
+		add_header Cache-Control "public";
+	}
+
+	# Any route containing a file extension (e.g. /devicesfile.js)
+	location ~ ^.+\..+$ {
+		try_files $uri =404;
+	}
+
+	# Any route that doesn't have a file extension (e.g. /devices)
 	location / {
-		try_files $uri /index.html;
+		try_files $uri $uri/ /index.html;
 	}
 }

--- a/mottak-arkiv-web/default.conf
+++ b/mottak-arkiv-web/default.conf
@@ -1,7 +1,7 @@
 server {
 	listen              80;
 	server_name         localhost;
-	root                /usr/share/nginx/html;
+	root                /app/public;
 	index               index.html index.htm;
 
 	location / {

--- a/mottak-arkiv-web/env.sh
+++ b/mottak-arkiv-web/env.sh
@@ -4,11 +4,11 @@ ENV_FILE=".env"
 ENV_VARIABLES="API_BASEURL"
 
 # Recreate config file
-rm -rf ./env-config.js
-touch ./env-config.js
+rm -rf ./public/env-config.js
+touch ./public/env-config.js
 
 # Add assignment
-echo "window._env_ = {" >> ./env-config.js
+echo "window._env_ = {" >> ./public/env-config.js
 
 if [ -f "$ENV_FILE" ]; then
   # Read each line in .env file
@@ -22,7 +22,7 @@ if [ -f "$ENV_FILE" ]; then
     fi
 
     # Append configuration property to JS file
-    echo "	$varname: '$varvalue'," >> ./env-config.js
+    echo "	$varname: '$varvalue'," >> ./public/env-config.js
   done < "$ENV_FILE"
 else
   # .env doesn't exist, needs to use env variables from list
@@ -32,8 +32,8 @@ else
     value=$(printenv $env_var)
 
     # Append configuration property to JS file
-    echo "	$env_var: '$value'," >> ./env-config.js
+    echo "	$env_var: '$value'," >> ./public/env-config.js
   done
 fi
 
-echo "}" >> ./env-config.js
+echo "}" >> ./public/env-config.js

--- a/mottak-arkiv-web/package.json
+++ b/mottak-arkiv-web/package.json
@@ -12,7 +12,7 @@
     "eject": "react-scripts eject",
     "lint": "yarn lint:eslint",
     "lint:eslint": "eslint 'src/**/*.{ts,tsx}'  --cache --report-unused-disable-directives",
-    "generate-env": "./env.sh && mv env-config.js public"
+    "generate-env": "./env.sh"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
We don't need to be in `/usr/share/nginx/html` in a container.
And moving nginx root to `/app/public` ensures the `env.sh` script isn't exposed